### PR TITLE
Improve game search for localized names

### DIFF
--- a/content.js
+++ b/content.js
@@ -15,7 +15,7 @@ function makeReadable(str) {
     return paragraphs;
 }
 
-function parseSearchApiXml(res) {
+function parseExactSearchApiXml(res) {
     const responseDoc = new DOMParser().parseFromString(res, 'application/xml')
     const gamesHtmlCollection = responseDoc.getElementsByTagName("item")
     if (gamesHtmlCollection.length >= 1) {
@@ -113,12 +113,12 @@ function parseGamedataApiXml(str) {
     return game
 }
 
-function findBGGGameId(gameName) {
+function findExactBGGGameId(gameName) {
     query = "https://www.boardgamegeek.com/xmlapi2/search?query=" + String(gameName).replaceAll(' ', '+').replaceAll(':', '+') + "&type=boardgame&exact=1";
     return (
         fetch(query)
             .then(searchResponse => searchResponse.text())
-            .then(searchText => parseSearchApiXml(searchText))
+            .then(searchText => parseExactSearchApiXml(searchText))
     )
 }
 
@@ -132,7 +132,7 @@ function findBGGGameInfo(gameId) {
 }
 
 async function displayGameInfo(gameName) {
-    const gameId = await findBGGGameId(gameName);
+    const gameId = await findExactBGGGameId(gameName);
     if (gameId === -1) {
         return;
     }


### PR DESCRIPTION
BGG is actually a pretty good place to search for games even when you're looking for the localized name, but the exact query being used is not ideal for such occasions.

In this PR I'm changing the code to try a "loose" search if the exact one fails, by:
1. Removing the exact parameter
2. Trimming the game name from parentheses (typically has the original game name)
3. Making sure the match on BGG has the same published date as the game on BGA

It's definitely not the best JavaScript, but it does the job, here are a couple test subjects I used:

![image](https://user-images.githubusercontent.com/6443427/135377434-1899c081-85ad-4455-a8af-57326441128a.png)
![image](https://user-images.githubusercontent.com/6443427/135377447-9abd4b4d-a71b-432f-aaa7-1c84c4898014.png)

One can argue that if the original name is within parentheses, we can instead extract just that and do an exact search again. One might be right, I just didn't test?